### PR TITLE
fix: support using mulitple `=` symbols in --docker-run-arg and --helm-install-arg

### DIFF
--- a/cmd/deploy/docker.go
+++ b/cmd/deploy/docker.go
@@ -63,7 +63,7 @@ cloud-cli deploy docker \
 			docker := getDockerCommand()
 			docker.AppendArgs("run")
 			for _, args := range opts.DockerRunArgs {
-				docker.AppendArgs(strings.Split(args, "=")...)
+				docker.AppendArgs(strings.SplitN(args, "=", 2)...)
 			}
 			docker.AppendArgs("--detach")
 

--- a/cmd/deploy/docker.go
+++ b/cmd/deploy/docker.go
@@ -43,6 +43,7 @@ cloud-cli deploy docker \
 		--name apisix-0 \
 		--apisix-image apache/apisix:2.11.0-centos \
 		--docker-run-arg --detach \
+		--docker-run-arg --mount=type=bind,source=/etc/hosts,target=/etc/hosts,readonly \
 		--docker-run-arg --hostname=apisix-1`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			if err := persistence.Init(); err != nil {
@@ -141,7 +142,7 @@ cloud-cli deploy docker \
 	}
 	cmd.PersistentFlags().StringVar(&options.Global.Deploy.Docker.APISIXImage, "apisix-image", "apache/apisix:2.11.0-centos", "Specify the Apache APISIX image")
 	cmd.PersistentFlags().StringVar(&options.Global.Deploy.Docker.DockerCLIPath, "docker-cli-path", "", "Specify the filepath of the docker command")
-	cmd.PersistentFlags().StringSliceVar(&options.Global.Deploy.Docker.DockerRunArgs, "docker-run-arg", []string{}, "Specify the arguments (in the format of name=value) for the docker run command")
+	cmd.PersistentFlags().StringSliceVar(&options.Global.Deploy.Docker.DockerRunArgs, "docker-run-arg", []string{}, "Specify the arguments (in the format of name=value, e.g. --mount=type=bind,source=/etc/hosts,target=/etc/hosts,readonly) for the docker run command")
 
 	return cmd
 }

--- a/cmd/deploy/kubernetes.go
+++ b/cmd/deploy/kubernetes.go
@@ -112,7 +112,7 @@ cloud-cli deploy kubernetes \
 						customizeValues = kv[1]
 						continue
 					}
-					helm.AppendArgs(strings.Split(args, "=")...)
+					helm.AppendArgs(strings.SplitN(args, "=", 2)...)
 				}
 
 				if customizeValues != "" {

--- a/cmd/deploy/kubernetes.go
+++ b/cmd/deploy/kubernetes.go
@@ -50,6 +50,7 @@ cloud-cli deploy kubernetes \
 		--namespace apisix \
 		--apisix-image apache/apisix:2.11.0-centos \
 		--helm-install-arg --output=table \
+		--helm-install-arg --set=apisix.image.tag=2.13.1-centos \
 		--helm-install-arg --wait`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			opts := &options.Global.Deploy.Kubernetes
@@ -138,7 +139,7 @@ cloud-cli deploy kubernetes \
 	cmd.PersistentFlags().StringVar(&options.Global.Deploy.Kubernetes.NameSpace, "namespace", "apisix", "Specify the Kubernetes name space")
 	cmd.PersistentFlags().StringVar(&options.Global.Deploy.Kubernetes.APISIXImage, "apisix-image", "apache/apisix:2.11.0-centos", "Specify the Apache APISIX image")
 	cmd.PersistentFlags().UintVar(&options.Global.Deploy.Kubernetes.ReplicaCount, "replica-count", 1, "Specify the pod replica count")
-	cmd.PersistentFlags().StringSliceVar(&options.Global.Deploy.Kubernetes.HelmInstallArgs, "helm-install-arg", []string{}, "Specify the arguments (in the format of name=value) for the helm install command")
+	cmd.PersistentFlags().StringSliceVar(&options.Global.Deploy.Kubernetes.HelmInstallArgs, "helm-install-arg", []string{}, "Specify the arguments (in the format of name=value, e.g. --set=apisix.image.tag=2.13.1-centos) for the helm install command")
 	cmd.PersistentFlags().StringVar(&options.Global.Deploy.Kubernetes.KubectlCLIPath, "kubectl-cli-path", "", "Specify the filepath of the kubectl command")
 	cmd.PersistentFlags().StringVar(&options.Global.Deploy.Kubernetes.HelmCLIPath, "helm-cli-path", "", "Specify the filepath of the helm command")
 

--- a/cmd/deploy/kubernetes_test.go
+++ b/cmd/deploy/kubernetes_test.go
@@ -120,6 +120,26 @@ func TestKubernetesDeployCommand(t *testing.T) {
 			},
 			mockCloud: defaultMockCloud,
 		},
+		{
+			name: "deploy on kubernetes with customize helm install --set options",
+			args: []string{"kubernetes", "--helm-install-arg", "--set=apisix.ingress.enabled=false"},
+			cmdPatterns: []string{
+				`kubectl create ns apisix`,
+				`kubectl create secret generic cloud-ssl --from-file tls.crt=.*?tls.crt --from-file tls.key=.*?tls.key --from-file ca.crt=.*?ca.crt --namespace apisix`,
+				`kubectl create configmap cloud-module --from-file cloud.ljbc=.*?cloud.ljbc --from-file cloud-agent.ljbc=.*?agent.ljbc --from-file cloud-metrics.ljbc=.*?metrics.ljbc --from-file cloud-utils.ljbc=.*?utils.ljbc --from-file cloud-file.ljbc=.*?file.ljbc --namespace apisix`,
+				`helm repo add apisix https://charts.apiseven.com`,
+				`helm repo update`,
+				`helm install apisix apisix/apisix --namespace apisix --set apisix.ingress.enabled=false`,
+				`Congratulations! Your APISIX cluster was deployed successfully on Kubernetes.`,
+				`The Helm release name is: apisix`,
+				`kubectl get deployment -n apisix -l app.kubernetes.io/instance=apisix -o jsonpath="\{.items\[0\].metadata.name\}"`,
+				`kubectl get pods -n apisix -l app.kubernetes.io/instance=apisix -o jsonpath="\{.items\[\*\].metadata.name\}"`,
+				`kubectl exec  -n apisix -- cat /usr/local/apisix/conf/apisix.uid`,
+				`kubectl wait --for condition=Ready --timeout 60s pod/ -n apisix`,
+				`kubectl get service -n apisix -l app.kubernetes.io/instance=apisix -o jsonpath="\{.items\[0\].metadata.name\}"`,
+			},
+			mockCloud: defaultMockCloud,
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc


### PR DESCRIPTION
Signed-off-by: tokers <zchao1995@gmail.com>