### PR TITLE
chore: set the minimum go version to 1.17

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Go Environment
         uses: actions/setup-go@v1
         with:
-          go-version: '1.16.5'
+          go-version: '1.17.10'
       - name: Run gofmt Check
         working-directory: ./
         run: |
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Go Environment
         uses: actions/setup-go@v1
         with:
-          go-version: '1.16.5'
+          go-version: '1.17.10'
       - name: Download golangci-lint
         run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.39.0
       - name: Run Golang Linters

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go Environment
         uses: actions/setup-go@v1
         with:
-          go-version: '1.16.5'
+          go-version: '1.17.10'
       - name: Build Cloud-cli binary
         run: |
           make build-all

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Go Environment
         uses: actions/setup-go@v1
         with:
-          go-version: '1.17'
+          go-version: '1.17.10'
       - name: Run Unit Test Suites
         working-directory: ./
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/api7/cloud-cli
 
-go 1.16
+go 1.17
 
 require (
 	github.com/fatih/color v1.13.0
@@ -11,6 +11,16 @@ require (
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/sys v0.0.0-20211205182925-97ca703d548d // indirect
 )
 
 require (


### PR DESCRIPTION
We want to support the arm64 version under windows. So we update the minimum go version to `1.17`.

Signed-off-by: tokers <zchao1995@gmail.com>