### PR TITLE
feat: support reload apisix runnning on bare metal

### DIFF
--- a/cmd/deploy/bare.go
+++ b/cmd/deploy/bare.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	_ "embed"
 	"os"
+	"path/filepath"
 	"text/template"
 	"time"
 
@@ -93,8 +94,8 @@ cloud-cli deploy bare \
 
 			var configFile string
 			if len(mergedConfig) > 0 {
-				configFile, err = apisix.SaveConfig(mergedConfig, "apisix-config-*.yaml")
-				if err != nil {
+				path := filepath.Join(os.TempDir(), "apisix-config-cloud.yaml")
+				if err = apisix.SaveConfig(mergedConfig, path); err != nil {
 					output.Errorf(err.Error())
 					return
 				}

--- a/cmd/deploy/bare_test.go
+++ b/cmd/deploy/bare_test.go
@@ -16,7 +16,6 @@ package deploy
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -261,7 +260,7 @@ fi
 			assert.Regexp(t, tc.cmdPattern, string(output), "check if the composed docker command is correct")
 
 			installFile := filepath.Join(persistence.HomeDir, "scripts/install.sh")
-			file, err := ioutil.ReadFile(installFile)
+			file, err := os.ReadFile(installFile)
 			assert.NoError(t, err, "check if dump the install script successful")
 			fmt.Println(string(file))
 			assert.Regexp(t, tc.installScript, string(file), "checking")

--- a/cmd/deploy/docker.go
+++ b/cmd/deploy/docker.go
@@ -86,7 +86,7 @@ cloud-cli deploy docker \
 				return
 			}
 			if len(mergedConfig) > 0 {
-				configFile, err := apisix.SaveConfig(mergedConfig, "apisix-config-*.yaml")
+				configFile, err := apisix.SaveConfigToTemp(mergedConfig, "apisix-config-*.yaml")
 				if err != nil {
 					output.Errorf(err.Error())
 					return

--- a/cmd/deploy/docker.go
+++ b/cmd/deploy/docker.go
@@ -17,7 +17,7 @@ package deploy
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -74,7 +74,7 @@ cloud-cli deploy docker \
 			docker.AppendArgs("--detach")
 
 			if options.Global.Deploy.APISIXConfigFile != "" {
-				data, err = ioutil.ReadFile(options.Global.Deploy.APISIXConfigFile)
+				data, err = os.ReadFile(options.Global.Deploy.APISIXConfigFile)
 				if err != nil {
 					output.Errorf("invalid --apisix-config-file option: %s", err)
 					return

--- a/cmd/deploy/kubernetes.go
+++ b/cmd/deploy/kubernetes.go
@@ -125,7 +125,7 @@ cloud-cli deploy kubernetes \
 				if mergedConfig, err = apisix.MergeConfig(data, ctx.essentialConfig); err != nil {
 					output.Errorf(err.Error())
 				}
-				if configFile, err = apisix.SaveConfig(mergedConfig, "helm-values-*.yaml"); err != nil {
+				if configFile, err = apisix.SaveConfigToTemp(mergedConfig, "helm-values-*.yaml"); err != nil {
 					output.Errorf(err.Error())
 				}
 				helm.AppendArgs("--values", configFile)

--- a/cmd/deploy/kubernetes.go
+++ b/cmd/deploy/kubernetes.go
@@ -16,7 +16,7 @@ package deploy
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -117,7 +117,7 @@ cloud-cli deploy kubernetes \
 				}
 
 				if customizeValues != "" {
-					if data, err = ioutil.ReadFile(customizeValues); err != nil {
+					if data, err = os.ReadFile(customizeValues); err != nil {
 						output.Errorf("invalid --apisix-config-file option: %s", err)
 					}
 				}

--- a/cmd/deploy/utils_test.go
+++ b/cmd/deploy/utils_test.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -278,7 +277,7 @@ etcd:
 				assert.Equal(t, tc.filledContext.cloudLuaModuleDir, ctx.cloudLuaModuleDir, "check cloud lua module dir")
 				assert.Equal(t, string(tc.filledContext.essentialConfig), string(ctx.essentialConfig), "check essential config")
 
-				id, err := ioutil.ReadFile(filepath.Join(persistence.HomeDir, "apisix.uid"))
+				id, err := os.ReadFile(filepath.Join(persistence.HomeDir, "apisix.uid"))
 				assert.Nil(t, err, "read apisix.uid")
 				// We cannot add an assertion if the ID was generated randomly.
 				if tc.specifiedAPISIXID != "" {

--- a/docs/deploy-apisix-on-bare-metal.md
+++ b/docs/deploy-apisix-on-bare-metal.md
@@ -88,6 +88,18 @@ Besides, Apache APISIX service will listen the ports `9080` for HTTP traffic and
 `9443` for HTTPS. Care must be taken here that you may suffer from the "port is
 already in use" issue if these ports were occupied.
 
+Reload Instance
+----------------
+
+Sometimes you may want to just update your custom APISIX configurations and reload APISIX, without
+the deployment step. In this case, you can run the deploy sub-command with `--reload` option.
+
+```shell
+cloud-cli deploy bare --reload
+```
+
+Note that you can use `--apisix-bin-path` to specify the APISIX binary file path, the default path is `/usr/bin/apisix`.
+
 Stop Instance
 -------------
 

--- a/internal/apisix/config_handler.go
+++ b/internal/apisix/config_handler.go
@@ -43,8 +43,8 @@ func MergeConfig(config []byte, defaultConfig []byte) (map[string]interface{}, e
 	return data, nil
 }
 
-// SaveConfig saves the config to the temporary file and return its name.
-func SaveConfig(config map[string]interface{}, pattern string) (string, error) {
+// SaveConfigToTemp saves the config to the temporary file and return its name.
+func SaveConfigToTemp(config map[string]interface{}, pattern string) (string, error) {
 	data, err := yaml.Marshal(config)
 	if err != nil {
 		return "", errors.Wrap(err, "marshal config")
@@ -63,4 +63,20 @@ func SaveConfig(config map[string]interface{}, pattern string) (string, error) {
 		return "", err
 	}
 	return tempFile.Name(), nil
+}
+
+// SaveConfig saves the config to the specified file.
+func SaveConfig(config map[string]interface{}, filepath string) error {
+	data, err := yaml.Marshal(config)
+	if err != nil {
+		return errors.Wrap(err, "marshal config")
+	}
+	if err = os.WriteFile(filepath, data, 0644); err != nil {
+		return err
+	}
+	// Assign permission for other users so that processes inside container can read it.
+	if err = os.Chmod(filepath, 0644); err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/apisix/config_handler.go
+++ b/internal/apisix/config_handler.go
@@ -15,7 +15,7 @@
 package apisix
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
@@ -49,7 +49,7 @@ func SaveConfig(config map[string]interface{}, pattern string) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "marshal config")
 	}
-	tempFile, err := ioutil.TempFile("", pattern)
+	tempFile, err := os.CreateTemp("", pattern)
 	if err != nil {
 		return "", err
 	}

--- a/internal/apisix/operations.go
+++ b/internal/apisix/operations.go
@@ -1,17 +1,16 @@
-//  Licensed to the Apache Software Foundation (ASF) under one or more
-//  contributor license agreements.  See the NOTICE file distributed with
-//  this work for additional information regarding copyright ownership.
-//  The ASF licenses this file to You under the Apache License, Version 2.0
-//  (the "License"); you may not use this file except in compliance with
-//  the License.  You may obtain a copy of the License at
+// Copyright 2022 API7.ai, Inc
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package apisix
 

--- a/internal/apisix/operations.go
+++ b/internal/apisix/operations.go
@@ -1,0 +1,33 @@
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package apisix
+
+import (
+	"context"
+	"github.com/api7/cloud-cli/internal/commands"
+	"github.com/api7/cloud-cli/internal/options"
+)
+
+// Reload reloads APISIX.
+// This function only supports for APISIX running on bare metal.
+func Reload(ctx context.Context) error {
+	bin := options.Global.Deploy.Bare.APISIXBinPath
+	dryrun := options.Global.DryRun
+	reload := commands.New(bin, dryrun)
+	reload.AppendArgs("reload")
+
+	return reload.Execute(ctx)
+}

--- a/internal/apisix/operations_test.go
+++ b/internal/apisix/operations_test.go
@@ -1,17 +1,16 @@
-//  Licensed to the Apache Software Foundation (ASF) under one or more
-//  contributor license agreements.  See the NOTICE file distributed with
-//  this work for additional information regarding copyright ownership.
-//  The ASF licenses this file to You under the Apache License, Version 2.0
-//  (the "License"); you may not use this file except in compliance with
-//  the License.  You may obtain a copy of the License at
+// Copyright 2022 API7.ai, Inc
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package apisix
 

--- a/internal/apisix/operations_test.go
+++ b/internal/apisix/operations_test.go
@@ -34,7 +34,7 @@ func TestReload(t *testing.T) {
 	}{
 		{
 			name:          "success",
-			apisixBinPath: "/usr/bin/echo",
+			apisixBinPath: "echo",
 		},
 	}
 

--- a/internal/apisix/operations_test.go
+++ b/internal/apisix/operations_test.go
@@ -1,0 +1,57 @@
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package apisix
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/api7/cloud-cli/internal/options"
+)
+
+func TestReload(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name               string
+		apisixBinPath      string
+		expectedErrMessage string
+	}{
+		{
+			name:          "success",
+			apisixBinPath: "/usr/bin/echo",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			options.Global.Deploy.Bare.APISIXBinPath = tc.apisixBinPath
+
+			err := Reload(context.Background())
+			if tc.expectedErrMessage == "" {
+				assert.Nil(t, err, "check reload error")
+			} else {
+				assert.NotNil(t, err, "check reload error")
+				assert.Containsf(t, err.Error(), tc.expectedErrMessage, "check reload error message")
+			}
+		})
+	}
+}

--- a/internal/cloud/api.go
+++ b/internal/cloud/api.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -74,7 +73,7 @@ func (a *api) GetCloudLuaModule() ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
 	}

--- a/internal/options/types.go
+++ b/internal/options/types.go
@@ -129,6 +129,10 @@ type DockerStopOptions struct {
 type BareDeployOptions struct {
 	// APISIXVersion specifies the APISIX version to deploy.
 	APISIXVersion string
+	// APISIXBinPath specifies the APISIX binary file path.
+	APISIXBinPath string
+	// Reload indicates if skip the deployment and just try to reload APISIX.
+	Reload bool
 }
 
 // KubernetesStopOptions contains options for the kubectl or helm command.

--- a/internal/persistence/certificate.go
+++ b/internal/persistence/certificate.go
@@ -15,7 +15,6 @@
 package persistence
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -44,7 +43,7 @@ func PrepareCertificate(cpID string) error {
 		return errors.Wrap(err, "download tls bundle")
 	}
 
-	err = ioutil.WriteFile(certFilename, []byte(bundle.Certificate), 0644)
+	err = os.WriteFile(certFilename, []byte(bundle.Certificate), 0644)
 	if err != nil {
 		return errors.Wrap(err, "save certificate")
 	}
@@ -54,7 +53,7 @@ func PrepareCertificate(cpID string) error {
 	}
 
 	certKeyFilename := filepath.Join(TLSDir, "tls.key")
-	err = ioutil.WriteFile(certKeyFilename, []byte(bundle.PrivateKey), 0644)
+	err = os.WriteFile(certKeyFilename, []byte(bundle.PrivateKey), 0644)
 	if err != nil {
 		return errors.Wrap(err, "save private key")
 	}
@@ -63,7 +62,7 @@ func PrepareCertificate(cpID string) error {
 	}
 
 	certCAFilename := filepath.Join(TLSDir, "ca.crt")
-	err = ioutil.WriteFile(certCAFilename, []byte(bundle.CACertificate), 0644)
+	err = os.WriteFile(certCAFilename, []byte(bundle.CACertificate), 0644)
 	if err != nil {
 		return errors.Wrap(err, "save ca certificate")
 	}
@@ -75,7 +74,7 @@ func PrepareCertificate(cpID string) error {
 }
 
 func checkIfCertificateAvailable(certFilename string) (bool, error) {
-	data, err := ioutil.ReadFile(certFilename)
+	data, err := os.ReadFile(certFilename)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil

--- a/internal/persistence/certificate_test.go
+++ b/internal/persistence/certificate_test.go
@@ -15,7 +15,6 @@
 package persistence
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -85,15 +84,15 @@ func TestPrepareCertificate(t *testing.T) {
 				certKeyFilename := filepath.Join(TLSDir, "tls.key")
 				certCAFilename := filepath.Join(TLSDir, "ca.crt")
 
-				err := ioutil.WriteFile(certFilename, []byte(tc.preparedCert), 0600)
+				err := os.WriteFile(certFilename, []byte(tc.preparedCert), 0600)
 				assert.Nil(t, err, "check if cert is saved")
 				defer os.Remove(certFilename)
 
-				err = ioutil.WriteFile(certKeyFilename, []byte(tc.preparedKey), 0600)
+				err = os.WriteFile(certKeyFilename, []byte(tc.preparedKey), 0600)
 				assert.Nil(t, err, "check if pkey is saved")
 				defer os.Remove(certKeyFilename)
 
-				err = ioutil.WriteFile(certCAFilename, []byte(tc.preparedCACert), 0600)
+				err = os.WriteFile(certCAFilename, []byte(tc.preparedCACert), 0600)
 				assert.Nil(t, err, "check if ca cert is saved")
 				defer os.Remove(certCAFilename)
 			}
@@ -109,11 +108,11 @@ func TestPrepareCertificate(t *testing.T) {
 				defer os.Remove(certFilename)
 				defer os.Remove(certKeyFilename)
 				defer os.Remove(certCAFilename)
-				cert, err := ioutil.ReadFile(certFilename)
+				cert, err := os.ReadFile(certFilename)
 				assert.Nil(t, err, "read cert")
-				pkey, err := ioutil.ReadFile(certKeyFilename)
+				pkey, err := os.ReadFile(certKeyFilename)
 				assert.Nil(t, err, "read pkey")
-				ca, err := ioutil.ReadFile(certCAFilename)
+				ca, err := os.ReadFile(certCAFilename)
 				assert.Nil(t, err, "read ca cert")
 
 				assert.Equal(t, tc.expectedCert, string(cert), "check cert")

--- a/internal/persistence/cloud_lua_module.go
+++ b/internal/persistence/cloud_lua_module.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -65,11 +64,11 @@ func SaveCloudLuaModule() (string, error) {
 			}
 		} else if hdr.Typeflag == tar.TypeReg {
 			filename := filepath.Join(HomeDir, hdr.Name)
-			buffer, err := ioutil.ReadAll(reader)
+			buffer, err := io.ReadAll(reader)
 			if err != nil {
 				return "", errors.Wrap(err, "failed to read tar")
 			}
-			if err := ioutil.WriteFile(filename, buffer, 0644); err != nil {
+			if err := os.WriteFile(filename, buffer, 0644); err != nil {
 				return "", errors.Wrap(err, "failed to save file")
 			}
 		}


### PR DESCRIPTION
This PR adds a new feature to reload APISIX running on bare metal. It adds two options for `cloud-cli deploy bare` sub-command.

* `--reload` to reload APISIX without the deployment step;
* `--apisix-bin-path` to specify the APISIX bin path, default path is `/usr/bin/apisix`;


Signed-off-by: tokers <zchao1995@gmail.com>