### PR TITLE
fix: installer.sh add support to aarch64

### DIFF
--- a/tools/installer.sh
+++ b/tools/installer.sh
@@ -57,6 +57,10 @@ if [ "$ARCH" = "x86_64" ]; then
   ARCH=amd64
 fi
 
+if [ "$ARCH" = "aarch64" ]; then
+  ARCH=arm64
+fi
+
 validate_arch $ARCH
 validate_os $OS
 install_cloud_cli $CLOUD_CLI_VER $OS $ARCH


### PR DESCRIPTION
When I used the installer in Rocky Linux Aarch64 in the `uname -m | tr A-Z a-z` command they return Aarch64 and not Arm64 and raising "Unsupported Arch: Aarch64".